### PR TITLE
Fixed "View All Articles" button 

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
             {% endif %}
         {% endfor %}
         <div class="btn-more text-right">
-            <a class="btn btn-default btn-xs twitchy-background" href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}">
+            <a class="btn btn-default btn-xs" href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}">
                 View all Articles ...
             </a>
         </div>


### PR DESCRIPTION
the "View All Articles..." button on index.html was showing with twitchy-background css class as dark bg-colour and dark font-color; was only readable when hovered.

Old Button (witch twitchy-background class):
![twitchy_old](https://cloud.githubusercontent.com/assets/3866457/21954015/534019cc-da46-11e6-8a05-8e243e037d05.JPG)

New after removing the class:
![twitchy_new](https://cloud.githubusercontent.com/assets/3866457/21954014/532c442e-da46-11e6-818f-b31276a2a42b.JPG)

