### PR TITLE
Add LinkedIn icon, and fix problem when displaying tags on menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -277,9 +277,9 @@
                 {% endif %}
                 {% if DISPLAY_TAGS_ON_MENU %}
                     {% if DISPLAY_TAGS_INLINE %}
-                        {% set tags = tag_cloud | sort(attribute='0') %}
+                        {% set tags_list = tag_cloud | sort(attribute='0') %}
                     {% else %}
-                        {% set tags = tag_cloud | sort(attribute='1') %}
+                        {% set tags_list = tag_cloud | sort(attribute='1') %}
                     {% endif %}
                 <li class="nav-divider"></li>
                 <li>
@@ -289,7 +289,7 @@
                     </a>
                 </li>
                 <li class="panel anti-panel"><ul id="collapse-tags" class="sidebar_submenu collapse {% block collapse_tags %}{% endblock %}">
-                    {% for tag in tags %}
+                    {% for tag in tags_list %}
                     <li class="tag-{{ tag.1 }}">
                         <a href="{{ SITEURL }}/{{ tag.0.url }}">
                             {{ tag.0 }}

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
 {%- endmacro %}
 {% macro get_icon_attributes(name) -%}
     {%- set name_sanitized = name|lower|replace('+','-plus')|replace(' ','-') -%}
-    {%- if name_sanitized in ['flickr', 'spotify', 'stack-overflow', 'bitbucket'] -%}
+    {%- if name_sanitized in ['flickr', 'spotify', 'stack-overflow', 'bitbucket', 'linkedin'] -%}
         {%- set iconattributes = 'fab fa-' ~ name_sanitized -%}
     {%- else -%}
         {%- set iconattributes = 'fab fa-' ~ name_sanitized ~ '-square' -%}


### PR DESCRIPTION
This PR introduces two changes:

1. Adds LinkedIn as an available socials menu icon.
2. Renames  "tags" to "tags_list" in base.html to fix a breaking problem which occurs when using the tag_cloud plugin and enabling DISPLAY_TAGS_ON_MENU as shown below:

```python
THEME = 'themes/pelican-twitchy/'
DISPLAY_TAGS_ON_MENU = True
PLUGIN_PATHS = ['pelican-plugins']
PLUGINS = ['tag_cloud']
```

The problem occurs due to a collision with the "tags" variable set in base.html and the built-in Pelican template. 

```shell
$ $ pelican --debug
...
~/pelican-test/venv/lib/python3.7/site-packages/pelican/themes/simple/templates/tags.html:9 in block 'content'                                                               
│                                                                                                  │
│    6 │   <h1>Tags for {{ SITENAME }}</h1>                                                        │
│    7 │   <ul>                                                                                    │
│    8 │   {% for tag, articles in tags|sort %}                                                    │
│ ❱  9 │   │   <li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> ({{ articles|count }})</    │
│   10 │   {% endfor %}                                                                            │
│   11 │   </ul>                                                                                   │
│   12 {% endblock %}                                                                              │
...
TypeError: object of type 'int' has no len()
```